### PR TITLE
ci: use default version of docker on circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,6 @@ machine:
   environment:
     # If you change this, you should change it in Dockerfile and Makefile.
     VERSION: 1.9.0
-  pre:
-    - sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.6.0-circleci'
-    - sudo chmod 0755 /usr/bin/docker
   services:
     - docker
 


### PR DESCRIPTION
circleci currently uses a version greater than what we pinned.
let's use it!