### PR TITLE
ci: use webhook to have microbadger inspect published images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,3 +42,4 @@ deployment:
       - docker push jumanjiman/aws:${TAG}
       - docker push jumanjiman/aws:latest
       - docker logout
+      - curl -X POST 'https://hooks.microbadger.com/images/jumanjiman/aws/Lan3ZPTzecbxGrzvkdxR-dTxIB8='


### PR DESCRIPTION
This ensures the badges reflect the latest information
as soon as images are published on the docker hub.

For now, mark the build as failed if the webhook fails.
Let's see how it goes.