### PR TITLE
add label for CI build URL to refer back to circleci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM alpine:3.4
 
+ARG CI_BUILD_URL
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
 
 LABEL \
+    io.github.jumanjiman.ci-build-url=$CI_BUILD_URL \
     io.github.jumanjiman.version=$VERSION \
     io.github.jumanjiman.build-date=$BUILD_DATE \
     io.github.jumanjiman.vcs-ref=$VCS_REF \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ clean:
 .PHONY: runtime
 runtime:
 	docker build \
+		--build-arg CI_BUILD_URL=${CIRCLE_BUILD_URL} \
 		--build-arg BUILD_DATE=${BUILD_DATE} \
 		--build-arg VCS_REF=${VCS_REF} \
 		--build-arg VERSION=${VERSION} \

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ BATS output resembles:
 
     ✓ awscli shows help with no options
     ✓ awscli is the correct version
+    ✓ ci-build-url label is present
 
-    2 tests, 0 failures
+    3 tests, 0 failures
 
 :warning: Build requires Docker 1.9.0 or higher for `--build-arg`.
 If you want to build locally, you must export an environment variable
@@ -42,6 +43,24 @@ to specify the `VERSION` of awscli.
 ### Pull an already-built image
 
     docker pull jumanjiman/aws
+
+
+### Labels
+
+Each built image has labels that generally follow http://label-schema.org/
+
+We add a label, `ci-build-url`, that is not currently part of the schema.
+This extra label provides a permanent link to the CI build for the image.
+
+View the ci-build-url label on a built image:
+
+    docker inspect \
+      -f '{{ index .Config.Labels "io.github.jumanjiman.ci-build-url" }}' \
+      jumanjiman/aws
+
+Query all the labels inside a built image:
+
+    docker inspect quay.io/iseexchange/flexlm | jq -M '.[].Config.Labels'
 
 
 ### Run

--- a/test/test_labels.bats
+++ b/test/test_labels.bats
@@ -1,0 +1,6 @@
+@test "ci-build-url label is present" {
+  run docker inspect \
+      -f '{{ index .Config.Labels "io.github.jumanjiman.ci-build-url" }}' \
+      jumanjiman/aws
+  [[ ${output} =~ circleci.com ]]
+}


### PR DESCRIPTION
This allows to inspect a built image and refer back to
a permanent link for the build on circleci.

It depends on env var `CIRCLE_BUILD_URL`, which gets set
on every build as described at
https://circleci.com/docs/environment-variables/

The Makefile gets executed on circleci on merge to master,
so the env var automatically exists for the build-and-publish
steps within cricleci.