### PR TITLE
ci: make check-files more readable

### DIFF
--- a/ci/check-files
+++ b/ci/check-files
@@ -13,34 +13,17 @@ usage() {
 EOF
 }
 
-# http://wiki.bash-hackers.org/howto/getopts_tutorial
-while getopts ":dhv:" opt; do
-  case ${opt} in
-    d)
-      verbosity=2
-      ;;
-    h)
-      usage
-      exit 0
-      ;;
-    v)
-      verbosity=${OPTARG}
-      ;;
-    \:)
-      usage
-      err option -${OPTARG} requires an argument
-      exit 1
-      ;;
-    \?|*)
-      usage
-      err invalid option -${OPTARG}
-      exit 1
-      ;;
-  esac
-done
-
-# After the shift, $* contains non-option arguments.
-shift $((OPTIND-1))
+main() {
+  # https://github.com/koalaman/shellcheck/wiki/SC2044
+  code=0
+  while IFS= read -r -d '' file; do
+    debug checking "${file}"
+    check_binary "${file}"        || code=1
+    check_shell_syntax "${file}"  || code=1
+    check_whitespace "${file}"    || code=1
+  done < <(git ls-files -z)
+  return ${code}
+}
 
 is_binary() {
   file="$1"
@@ -79,20 +62,47 @@ check_shell_syntax() {
 check_whitespace() {
   file="$1"
   if $(is_binary "${file}"); then
-    : # Binary files can have trailing whitespace.
-  elif grep -E '\s$' "${file}"; then
+    # Binary files can have trailing whitespace.
+    return 0
+  fi
+  if [[ ${verbosity} -ge 2 ]]; then
+    grep -E '\s$' "${file}"
+  else
+    grep -E '\s$' "${file}" &> /dev/null
+  fi
+  if [[ $? -eq 0 ]]; then
     err \"${file}\" has trailing whitespace
     return 1
   fi
 }
 
-# https://github.com/koalaman/shellcheck/wiki/SC2044
-code=0
-while IFS= read -r -d '' file; do
-  debug checking "${file}"
-  check_binary "${file}"        || code=1
-  check_shell_syntax "${file}"  || code=1
-  check_whitespace "${file}"    || code=1
-done < <(git ls-files -z)
+# http://wiki.bash-hackers.org/howto/getopts_tutorial
+while getopts ":dhv:" opt; do
+  case ${opt} in
+    d)
+      verbosity=2
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    v)
+      verbosity=${OPTARG}
+      ;;
+    \:)
+      usage
+      err option -${OPTARG} requires an argument
+      exit 1
+      ;;
+    \?|*)
+      usage
+      err invalid option -${OPTARG}
+      exit 1
+      ;;
+  esac
+done
 
-exit ${code}
+# After the shift, $* contains non-option arguments.
+shift $((OPTIND-1))
+
+main

--- a/ci/test
+++ b/ci/test
@@ -10,4 +10,6 @@ bats test/test_*.bats
 
 echo
 echo Check every file for things like trailing whitespace.
+# Hint: -v1 shows just the names of offending files.
+#       -v2 shows lines with trailing whitespace.
 ci/check-files -v1


### PR DESCRIPTION
From the top, the script has
`usage()`, then `main()`, then other functions.

Details of option handling are near the bottom,
just before the script invokes `main()`.

Update the check for trailing whitespace:

* By default, only show the name of an offending file.
* If verbosity >= 2, show both the name and the actual offense.