### PR TITLE
ci: be more informative during build/test on hosted ci

### DIFF
--- a/ci/build
+++ b/ci/build
@@ -34,8 +34,10 @@ if [[ ${AUTOBUILD} = true ]]; then
   dock_latest=$(microbadger -name jumanjiman/aws | awk '/version/ {print $NF}')
   VERSION=${pypi_latest}
 
+  info "pypi version is \"${pypi_latest}\" according to pypi."
+  info "dock version is \"${dock_latest}\" according to microbadger."
+
   if [[ ${pypi_latest} = "${dock_latest}" ]]; then
-    echo "Nothing to do."
     UP2DATE=true
   fi
 fi
@@ -50,9 +52,10 @@ declare -rx TAG=\${VERSION}-\${BUILD_DATE}-git-\${VCS_REF}
 EOF
 
 . ci/vars
-[[ ${UP2DATE} = true ]] && exit 0
-
-docker-compose build
-
-docker images
-docker inspect jumanjiman/aws
+if [[ ${UP2DATE} = true ]]; then
+  info "Image is up-to-date on docker hub; nothing to do."
+else
+  docker-compose build
+  docker images
+  docker inspect jumanjiman/aws
+fi

--- a/ci/publish
+++ b/ci/publish
@@ -7,15 +7,37 @@ set -o pipefail
 # Publish the aws images to Docker Hub.
 ################################################################################
 
+main() {
+  if [[ ${UP2DATE} == true ]]; then
+    info 'Image is up-to-date on docker hub; nothing to do.'
+  else
+    publish
+  fi
+
+  # Ensure Microbadger has latest metadata.
+  poke_microbadger
+}
+
+publish() {
+  # shellcheck disable=SC2154
+  docker login -u "${user}" -p "${pass}"
+  docker tag jumanjiman/aws jumanjiman/aws:"${TAG}"
+  docker push jumanjiman/aws:"${TAG}"
+  docker push jumanjiman/aws:latest
+  docker logout
+}
+
+poke_microbadger() {
+  echo -n 'INFO: microbadger '
+  curl -X POST 'https://hooks.microbadger.com/images/jumanjiman/aws/Lan3ZPTzecbxGrzvkdxR-dTxIB8='
+  echo
+}
+
+################################################################################
+# Program execution starts here.
+################################################################################
+
 . ci/helpers.sh
 . ci/vars
-[[ ${UP2DATE} == true ]] && exit 0
 
-# shellcheck disable=SC2154
-docker login -u "${user}" -p "${pass}"
-docker tag jumanjiman/aws jumanjiman/aws:"${TAG}"
-docker push jumanjiman/aws:"${TAG}"
-docker push jumanjiman/aws:latest
-docker logout
-
-curl -X POST 'https://hooks.microbadger.com/images/jumanjiman/aws/Lan3ZPTzecbxGrzvkdxR-dTxIB8='
+main

--- a/ci/test
+++ b/ci/test
@@ -8,20 +8,39 @@ set -o pipefail
 # Invoke as "ci/test".
 ################################################################################
 
+main() {
+  check_files
+
+  if [[ ${UP2DATE} = true ]]; then
+    info "Image is up-to-date on docker hub; nothing left to do."
+  else
+    run_bats
+  fi
+}
+
+check_files() {
+  echo
+  echo Check every file for things like trailing whitespace.
+  # Hint: -v1 shows just the names of offending files.
+  #       -v2 shows lines with trailing whitespace.
+  ci/check-files -v2
+
+  if command -v shellcheck &> /dev/null; then
+    shellcheck ci/vars
+  fi
+}
+
+run_bats() {
+  echo
+  echo Invoke BATS tests.
+  bats ci/test_*.bats
+}
+
+################################################################################
+# Program execution starts here.
+################################################################################
+
 . ci/helpers.sh
 . ci/vars
-[[ ${UP2DATE} = true ]] && exit 0
 
-if command -v shellcheck &> /dev/null; then
-  shellcheck ci/vars
-fi
-
-echo
-echo Invoke BATS tests.
-bats ci/test_*.bats
-
-echo
-echo Check every file for things like trailing whitespace.
-# Hint: -v1 shows just the names of offending files.
-#       -v2 shows lines with trailing whitespace.
-ci/check-files -v2
+main


### PR DESCRIPTION
The tag sometimes gets rebuilt during autobuild
when there has been no change in upstream awscli version.

This commit prints info during autobuild to show why it rebuilds.