### PR TITLE
ci: do not create spurious file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
       - run:
           name: Build the image
           command: |
-            VERSION=<< parameters.awscli_version >> AUTOBUILD='<< parameters.autobuild >>' ci/build
+            VERSION='<< parameters.awscli_version >>' AUTOBUILD='<< parameters.autobuild >>' ci/build
 
       - run:
           name: Test the image


### PR DESCRIPTION
Fix strange behavior.
A file was created called `AUTOBUILD=<< parameters.autobuild >>`
as seen at:

* https://circleci.com/gh/jumanjihouse/docker-aws/3200
* https://circleci.com/gh/jumanjihouse/docker-aws/3201

I suspect it may have been caused by my trigger script,
which invoked an API build.

I forgot to disable my trigger timer when I merged
0b25fc2bb790d0daa8be14380d26ed50a96622ad, but I now
disabled that API script.